### PR TITLE
Visually hide the textarea element

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: node_js
 node_js:
-    - 4
-    - 5
-
-branches:
-  only:
-    - gh-pages
-    
-before_install:
-  - npm install gulp -g
+    - 10
+    - 8
 
 script:
-  - npm test
+  - npm run lint
+  - npm run coverage && npm run report
 
 notifications:
     email:
-        on_success: never
+        on_success: change
         on_failure: change
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Async Clipboard [![License][LicenseIMGURL]][LicenseURL] [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL] [![Build Status][BuildStatusIMGURL]][BuildStatusURL] [![Coverage Status][CoverageIMGURL]][CoverageURL]
 
-[Async clipboard api](https://w3c.github.io/clipboard-apis/) uses `navigator.clipboard` if available or polyfill.
+[Async clipboard api](https://w3c.github.io/clipboard-apis/) uses `navigator.clipboard` if available or smallest `polyfill` in the world.
 
 ## Install
 

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -22,6 +22,6 @@ function writeText(value) {
     if (is)
         return Promise.resolve();
      
-     return Promise.reject();
+    return Promise.reject();
 }
 

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -22,6 +22,6 @@ function writeText(value) {
     if (is)
         return Promise.resolve();
      
-    return Promise.reject();
+     return Promise.reject();
 }
 

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -11,6 +11,9 @@ function readText() {
 
 function writeText(value) {
     const el = document.createElement('textarea');
+    
+    el.style.display = 'none';
+    el.setAttribute('aria-hidden', 'true');
     el.value = value;
     
     document.body.appendChild(el);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
     "nodemon": "^1.17.4",
     "nyc": "^11.7.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
     "nodemon": "^1.17.4",
-    "nyc": "^11.7.3",
+    "nyc": "^12.0.2",
     "redrun": "^6.0.4",
     "sinon": "^5.0.7",
     "sinon-called-with-diff": "^2.1.1",

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -224,7 +224,7 @@ test('clipboard: writeText: reject', async (t) => {
         t.fail('should not resolve');
     } catch(e) {
         t.pass('should reject');
-    };
+    }
     
     global.navigator = navigator;
     global.document = document;


### PR DESCRIPTION
This prevents jumping on smaller viewports—specifically iOS devices.