### PR TITLE
Update textarea hiding method

### DIFF
--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -13,8 +13,11 @@ function writeText(value) {
     const el = document.createElement('textarea');
     
     el.hidden = true;
-    el.setAttribute('aria-hidden', 'true');
-    el.value = value;
+    el.style.cssText = `
+        opacity: 0;
+        position: fixed;
+        top: 50%;
+    `;
     
     document.body.appendChild(el);
     el.select();


### PR DESCRIPTION
Hey again! 

I've been testing the addition I made earlier some more and Firefox wasn't digging the fact that the textarea was fully hidden.

This new approach stops the page jumping and 'hides' it too.

Thanks again :) 